### PR TITLE
Translate stories README to English

### DIFF
--- a/stories/README.md
+++ b/stories/README.md
@@ -1,12 +1,12 @@
-| 地域   | 名称                | 時代         | 特徴                                   | 主な例             |
-| ---- | ----------------- | ---------- | ------------------------------------ | --------------- |
-| ギリシャ | **イソップ寓話**        | 紀元前6世紀頃    | 動物を主人公にした短編寓話。人間社会の風刺・道徳教訓を表現。       | 兎と亀、狼少年、蟻とキリギリス |
-| インド  | **パンチャタントラ**      | 紀元前3世紀頃    | 王子に知恵を授けるための動物寓話集。処世術・政治教育色が強い。      | カラスと壺の水、亀と二羽の白鳥 |
-| 中東   | **カリーラとディムナ**     | 8世紀頃       | パンチャタントラがアラビア語に翻訳され普及。イスラム世界で広く読まれる。 | ライオンと牛の友情       |
-| フランス | **ラ・フォンテーヌ寓話**    | 17世紀       | イソップを詩形式で翻案。貴族・庶民双方に人気。              | 狐と葡萄、カラスと狐      |
-| ドイツ  | **グリム童話**         | 19世紀       | 民話・口承を収集。寓話性というより物語性が強い。             | 白雪姫、ヘンゼルとグレーテル  |
-| 中国   | **韓非子の寓話**        | 紀元前3世紀     | 政治哲学書に寓話を収録。権力や人間心理の教訓。              | 守株待兎、狐虎の威       |
-| 中国   | **荘子の寓話**         | 紀元前4世紀     | 禅的・哲学的な寓話。夢や動物を通じて世界観を提示。            | 胡蝶の夢、魚と大鳥の話     |
-| アラブ  | **千夜一夜物語**        | 9世紀頃       | 長編枠組みに短編寓話が多数挿入。娯楽性と教訓性が混在。          | アラジン、シンドバッド     |
-| 日本   | **日本昔話**          | 古代〜近世      | 民話・口承伝承。道徳や教訓を含むが娯楽性も大。              | 桃太郎、浦島太郎、一寸法師   |
-| 日本   | **一休さん（逸話・とんち話）** | 室町時代（15世紀） | 禅僧一休宗純の逸話。知恵・機転・ユーモアに富む。             | 屏風の虎、このはし渡るべからず |
+| Region | Title | Era | Features | Notable Examples |
+| --- | --- | --- | --- | --- |
+| Greece | **Aesop's Fables** | around 6th century BCE | Short fables featuring animals as protagonists, expressing satire and moral lessons about human society. | The Tortoise and the Hare; The Boy Who Cried Wolf; The Ant and the Grasshopper |
+| India | **Panchatantra** | around 3rd century BCE | Collection of animal fables meant to impart wisdom to princes, with a strong emphasis on practical and political education. | The Crow and the Pitcher; The Tortoise and the Two Swans |
+| Middle East | **Kalila wa Dimna** | around 8th century | Arabic translation of the Panchatantra that spread widely across the Islamic world. | The Lion and the Bull |
+| France | **La Fontaine's Fables** | 17th century | Versified adaptations of Aesop's tales, popular among both nobility and commoners. | The Fox and the Grapes; The Crow and the Fox |
+| Germany | **Grimm's Fairy Tales** | 19th century | Collection of folk and oral tales, emphasizing storytelling rather than moralizing. | Snow White; Hansel and Gretel |
+| China | **Fables of Han Feizi** | 3rd century BCE | Political philosophy text containing fables with lessons on power and human psychology. | Waiting for a Rabbit by a Tree Stump; The Fox Borrowing the Tiger's Authority |
+| China | **Fables of Zhuangzi** | 4th century BCE | Zen-like philosophical fables that present a worldview through dreams and animals. | The Butterfly Dream; The Fish and the Giant Bird |
+| Arab World | **One Thousand and One Nights** | around 9th century | Long framing narrative containing many short fables, mixing entertainment with moral instruction. | Aladdin; Sinbad |
+| Japan | **Japanese Folktales** | Ancient to early modern times | Folk and oral traditions that include morals and lessons yet emphasize entertainment. | Momotaro; Urashima Taro; Issun-boshi |
+| Japan | **Ikkyu-san (Anecdotes and Witty Tales)** | Muromachi period (15th century) | Anecdotes of the Zen monk Ikkyu Sojun, rich in wisdom, quick wit, and humor. | The Tiger in the Folding Screen; "Do Not Cross This Bridge" |


### PR DESCRIPTION
## Summary
- Translate `stories/README.md` into English with a table of global fables and examples.

## Testing
- `pytest -q`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa47e2a8a4833099a0efcb06302433