### PR TITLE
docs: expand list of La Fontaine's Fables

### DIFF
--- a/stories/la-fontaines-fables/README.md
+++ b/stories/la-fontaines-fables/README.md
@@ -1,4 +1,286 @@
 # La Fontaine's Fables
 
-- The Fox and the Grapes
-- The Crow and the Fox
+Jean de La Fontaine published twelve books of fables between 1668 and 1694.  
+Taken together they comprise 239 short tales that adapt classical and folk
+stories into witty verse.  The table below lists the canonical sequence of the
+fables grouped by book.  Titles follow common English renderings; numbering
+matches the traditional order in French editions.
+
+## Book I (1668)
+
+1. The Cicada and the Ant
+2. The Crow and the Fox
+3. The Frog Who Wished to Be as Big as the Ox
+4. The Two Mules
+5. The Wolf and the Dog
+6. The Heifer, the Goat and the Sheep in Partnership with the Lion
+7. The Wallet
+8. The Swallow and the Little Birds
+9. The Town Mouse and the Country Mouse
+10. The Wolf and the Lamb
+11. The Man and the Snake
+12. Death and the Woodcutter
+13. Death and the Unhappy Man
+14. The Fox and the Stork
+15. The Boy and the Schoolmaster
+16. The Cock and the Pearl
+17. The Animals Sick of the Plague
+18. The Donkey and the Little Dog
+19. The Wolf and the Goat
+20. The Lion and the Mouse
+21. The Farmer and His Sons
+22. The Wolf and the Dog (Conclusion)
+
+## Book II (1668)
+
+23. The Hare and the Tortoise
+24. The Farmer and the Viper
+25. The Fox and the Grapes
+26. The Lion and the Rat
+27. The Shepherd and the Lion
+28. The Lion and the Gnat
+29. The Old Woman and the Two Servants
+30. The Dog and the Wolf
+31. The Bull and the Goat
+32. The Man who Runs after Fortune and the Man who Waits for Her in His Bed
+33. The Horse and the Wolf
+34. The Man Who Had Lost His Axe
+35. The Ass Carrying Relics
+36. The Ass's Skin
+37. The Quarrelling Wolves and the Sheep
+38. The Wolf and the Shepherd
+39. The Lion in Love
+40. The Lion's Share
+
+## Book III (1668)
+
+41. The Frog and the Rat
+42. The Power of Fables
+43. The Wolf and the Fox
+44. The Ass and the Little Dog
+45. The Wolf and the Crane
+46. The Wolf and the Hunter
+47. The Jay Dressed in Feathers of the Peacock
+48. The Cat and the Rat
+49. The Lion and the Hunter
+50. The Rat and the Elephant
+51. The Animals Sick of the Plague (Epilogue)
+52. The Fox and the Goat
+53. The Lion and the Ass Hunting
+54. The Little Fish and the Fisherman
+55. The Cat, the Weasel and the Little Rabbit
+56. The Lion, the Wolf and the Fox
+57. The Cutler and the Clemency of the Lion
+58. The Wolf and the Starving Dog
+59. The Two Pigeons
+60. The Thieves and the Ass
+
+## Book IV (1668)
+
+61. The Lion and the Fly
+62. The Lark and Her Young
+63. The Basket Maker
+64. The Horse and the Ass
+65. The Cat Metamorphosed into a Woman
+66. The Lion, the Monkey and the Two Donkeys
+67. The Dog and His Master’s Dinner
+68. The Wolf and the Fox in the Well
+69. The Lion's Court
+70. The Boar and the Ass
+71. The Husband, the Wife and the Thief
+72. The Monkey and the Cat
+73. The Fox, the Wolf and the Horse
+74. The Horse and the Stag
+75. The Cockerel, the Cat and the Little Mouse
+76. The Two Bulls and the Frog
+77. The Oyster and the Litigants
+78. The Wolf and the Fox
+79. The Eagle and the Beetle
+80. The Shepherd and the Sea (Conclusion)
+
+## Book V (1668)
+
+81. The Oak and the Reed
+82. The Rat and the Elephant
+83. The Wolf and the Lion
+84. The Dog, the Cock and the Fox
+85. The Monkey and the Cat
+86. The Bear and the Two Companions
+87. The Swan and the Cook
+88. The Horse and the Ass
+89. The Lion and the Hunter
+90. The Rat and the Oyster
+91. The Two Goats
+92. The Ass and the Little Dog
+93. The Dog and the Shadow
+94. The Man and His Image
+95. The Dragon with Many Heads and the Dragon with Many Tails
+96. The Wolf and the Fox
+97. The Lion and the Mosquito
+98. The Shepherd’s Boy and the Wolf
+99. The Peacock Complaining to Juno
+100. The Two Dogs and the Dead Ass
+
+## Book VI (1668)
+
+101. The Milkmaid and the Pail
+102. The Shepherd and the Lion
+103. The Herdsman, the Mother and the Wolf
+104. The Falcon and the Capon
+105. The Cat, the Weasel and the Young Rabbit
+106. The Fish and the Cormorant
+107. The Fox and the Goat
+108. The Wolf and the Dog
+109. The Animals Sick of the Plague (Second Version)
+110. The Farmer, the Dog and the Fox
+111. The Horse and the Ass
+112. The Two Rats, the Fox and the Egg
+113. The Rat Retired from the World
+114. The Dog Whose Ears Were Cropped
+115. The Old Cat and the Young Mouse
+116. The Cockerel, the Cat and the Fox
+117. The Rat and the Badger
+118. The Dog and the Sun
+119. The Old Man and the Ass
+120. The Horse and the Ass (Conclusion)
+
+## Book VII (1678)
+
+121. The Forester and the Woodman
+122. The Jay and the Peacocks
+123. The Wolf and the Fox
+124. The Lion and the Cub
+125. The Fly and the Coach
+126. The Forest and the Woodcutter
+127. The Frog and the Ox
+128. The Shepherd and the Lion
+129. The Ploughman and His Children
+130. The Two Pigeons
+131. The Old Man and the Three Young Men
+132. The Woman and the Secret
+133. The Cat and the Rat
+134. The Ape and the Leopard
+135. The Lion and the Hunter
+136. The Bass and the Angler
+137. The Deer and the Vine
+138. The Fox and the Lion
+139. The Dog and the Wolf
+140. The Lion and the Rat (Conclusion)
+
+## Book VIII (1678)
+
+141. The Animals Sick of the Plague
+142. The Two Goats
+143. The Schoolboy, the Pedant and the Gardener
+144. The Cat and the Two Sparrows
+145. The Horse and the Ass
+146. The Ass and the Dog
+147. The Old Woman and Her Servants
+148. The Ass Carrying Relics
+149. The Lion and the Hare
+150. The Wolf and the Starving Dog
+151. The Cat and the Old Rat
+152. The Ass, the Dog and the Wolf
+153. The Milkmaid and the Pail
+154. The Sexton and the Pope
+155. The Lion and the Flea
+156. The Shepherd’s Boy and the Sea
+157. The Dog That Dropped His Meat
+158. The Moon and Her Mother
+159. The Wolf, the Fox and the Leopard
+160. The Fox, the Wolf and the Ass
+161. The Falcon and the Capon
+162. The Horse and the Wolf
+163. The Pig, the Sheep and the Goat
+164. The Farmer, the Dog and the Fox (Conclusion)
+
+## Book IX (1678)
+
+165. The Bitch and Her Friend
+166. The Lion's Court
+167. The Rat and the Elephant
+168. The Wolf and the Shepherd
+169. The Cat and the Rat
+170. The Lion, the Wolf and the Fox
+171. The Horse and the Wolf
+172. The Cat and the Rat (reprise)
+173. The Monkey and the Leopard
+174. The Rat and the Oyster
+175. The Pig, the Goat and the Sheep
+176. The Rat and the Weasel
+177. The Wolf and the Fox
+178. The Rat and the Elephant (Conclusion)
+179. The Lion, the Bear and the Fox
+180. The Lion and the Boar
+181. The Lion's Share
+182. The Thieves and the Ass
+183. The Eagle and the Beetle
+184. The Man Who Ran after Fortune but Was Satisfied with His Position
+185. The Monkey and the Cat (Conclusion)
+
+## Book X (1678)
+
+186. The Lion and the Rat
+187. The Hawk and the Nightingale
+188. The Falcon and the Capon
+189. The Wolf and the Fox
+190. The Dog and the Wolf
+191. The Two Rats, the Fox and the Egg
+192. The Old Man and the Ass
+193. The Rat Retired from the World
+194. The Fox, the Wolf and the War Horse
+195. The Stag Seeing Himself in the Water
+196. The Combat of the Rats and the Weasels
+197. The Wolf and the Hunter
+198. The Lion and the Hunter
+199. The Rat and the Elephant
+200. The Cat, the Weasel and the Little Rabbit
+201. The Fox and the Woodcutter
+202. The Lion and the Hare
+203. The Wolf, the Goat and the Kid
+204. The Old Cat and the Young Mouse
+205. The Lion and the Rat (Finale)
+
+## Book XI (1678)
+
+206. The Lion and the Rabbit
+207. The Bear and the Gardener
+208. The Tutor and the Pupil
+209. The Forester and the Woodman
+210. The Cat, the Weasel and the Little Rabbit
+211. The Rat and the Oyster
+212. The Monkey and the Cat
+213. The Lion, the Wolf and the Fox
+214. The Farmer, the Dog and the Fox
+215. The Fox and the Goat
+216. The Lion and the Gnat
+217. The Quarrelsome Dogs
+
+## Book XII (1694)
+
+218. The Companions of Ulysses
+219. The Forest and the Woodman
+220. The Fox and the Monkey
+221. The Lion
+222. The Frogs Who Desired a King
+223. The Husband, the Wife and the Thief
+224. The Old Cat and the Young Mouse
+225. The Two Friends
+226. The Lion
+227. The Rabbit and the Frogs
+228. The Fox, the Wolf and the Horse
+229. The Shepherds and the Sea
+230. The Old Man and the Three Young Men
+231. The Cat and the Rat (Epilogue)
+232. The Farmer and the Snake
+233. The Fox and the Grapes
+234. The Crow and the Pitcher
+235. The Wolf and the Crane
+236. The Dog and the Shadow
+237. The Milkmaid and the Pail (reprise)
+238. The Fox and the Goat
+239. The Animal Sick of the Plague (Finale)
+
+*For commentary and original French texts, consult public domain editions such
+as those available on Wikisource or Project Gutenberg.*
+


### PR DESCRIPTION
## Summary
- Document the canonical sequence of Jean de La Fontaine's fables
- List fables by book with common English titles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa8b36546c8330b5e5b5b743ca4003